### PR TITLE
Add paginated shop collection page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -63,6 +63,10 @@ body {
   color: #bfcdf5;
 }
 
+.hero-actions {
+  margin: 1rem 0 0;
+}
+
 .collection-header {
   margin: 2rem 0 1rem;
 }
@@ -127,6 +131,44 @@ body {
   display: inline-block;
   font-weight: 700;
   color: #9bc0ff;
+}
+
+.pagination-nav {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.2rem;
+}
+
+.pagination-link {
+  display: inline-block;
+  border-radius: 999px;
+  border: 1px solid rgba(180, 198, 243, 0.45);
+  color: #e9f0ff;
+  text-decoration: none;
+  padding: 0.45rem 0.95rem;
+  background: rgba(28, 49, 98, 0.45);
+}
+
+.pagination-link.disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.empty-state {
+  margin-top: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  background: rgba(8, 14, 28, 0.7);
+}
+
+.empty-state h2 {
+  margin: 0;
+}
+
+.empty-state p {
+  margin: 0.6rem 0 1rem;
+  color: #d2defd;
 }
 
 .product-breadcrumb a {

--- a/app/controllers/storefront_controller.rb
+++ b/app/controllers/storefront_controller.rb
@@ -4,6 +4,15 @@ class StorefrontController < ApplicationController
     @shopify_connected = ENV["SHOPIFY_STORE_DOMAIN"].present? && ENV["SHOPIFY_STOREFRONT_ACCESS_TOKEN"].present?
   end
 
+  def shop
+    @shopify_connected = ENV["SHOPIFY_STORE_DOMAIN"].present? && ENV["SHOPIFY_STOREFRONT_ACCESS_TOKEN"].present?
+    @catalog_page = Shopify::ProductCatalog.new.page(
+      first: per_page,
+      after: params[:after],
+      before: params[:before]
+    )
+  end
+
   def show
     @product = Shopify::ProductCatalog.new.find(params[:id])
     return render_not_found if @product.blank?
@@ -12,6 +21,13 @@ class StorefrontController < ApplicationController
   end
 
   private
+
+  def per_page
+    requested = params[:per].to_i
+    return 12 if requested <= 0
+
+    [requested, 24].min
+  end
 
   def render_not_found
     render file: Rails.public_path.join("404.html"), layout: false, status: :not_found

--- a/app/models/product_page.rb
+++ b/app/models/product_page.rb
@@ -1,0 +1,13 @@
+class ProductPage
+  attr_reader :products, :next_cursor, :prev_cursor
+
+  def initialize(products:, next_cursor:, prev_cursor:)
+    @products = products
+    @next_cursor = next_cursor
+    @prev_cursor = prev_cursor
+  end
+
+  def empty?
+    @products.empty?
+  end
+end

--- a/app/services/shopify/product_catalog.rb
+++ b/app/services/shopify/product_catalog.rb
@@ -1,4 +1,5 @@
 require "cgi"
+require "base64"
 
 module Shopify
   class ProductCatalog
@@ -20,6 +21,66 @@ module Shopify
                 currencyCode
               }
             }
+          }
+        }
+      }
+    GRAPHQL
+
+    PRODUCTS_PAGE_FORWARD_QUERY = <<~GRAPHQL
+      query ProductsPageForward($first: Int!, $after: String) {
+        products(first: $first, after: $after, sortKey: BEST_SELLING) {
+          edges {
+            cursor
+            node {
+              id
+              handle
+              title
+              description
+              featuredImage {
+                url
+                altText
+              }
+              priceRange {
+                minVariantPrice {
+                  amount
+                  currencyCode
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+        }
+      }
+    GRAPHQL
+
+    PRODUCTS_PAGE_BACKWARD_QUERY = <<~GRAPHQL
+      query ProductsPageBackward($last: Int!, $before: String) {
+        products(last: $last, before: $before, sortKey: BEST_SELLING) {
+          edges {
+            cursor
+            node {
+              id
+              handle
+              title
+              description
+              featuredImage {
+                url
+                altText
+              }
+              priceRange {
+                minVariantPrice {
+                  amount
+                  currencyCode
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
           }
         }
       }
@@ -74,13 +135,19 @@ module Shopify
     end
 
     def featured(limit: 6)
-      return fallback_products if !@client.configured?
+      return fallback_products.first(limit) if !@client.configured?
 
       data = @client.query(query: FEATURED_PRODUCTS_QUERY, variables: { first: limit })
       nodes = data&.dig("products", "nodes")
-      return fallback_products if nodes.blank?
+      return fallback_products.first(limit) if nodes.blank?
 
       nodes.map { |node| to_product_card(node, truncate_description: true) }
+    end
+
+    def page(first:, after: nil, before: nil)
+      return fallback_page(first: first, after: after, before: before) if !@client.configured?
+
+      live_page(first: first, after: after, before: before) || fallback_page(first: first, after: after, before: before)
     end
 
     def find(identifier)
@@ -95,6 +162,65 @@ module Shopify
     end
 
     private
+
+    def live_page(first:, after:, before:)
+      if before.present?
+        data = @client.query(query: PRODUCTS_PAGE_BACKWARD_QUERY, variables: { last: first, before: before })
+      else
+        data = @client.query(query: PRODUCTS_PAGE_FORWARD_QUERY, variables: { first: first, after: after })
+      end
+
+      products_data = data&.dig("products")
+      return nil if products_data.blank?
+
+      edges = products_data["edges"] || []
+      product_cards = edges.map { |edge| to_product_card(edge["node"], truncate_description: true) }
+      page_info = products_data["pageInfo"] || {}
+
+      ProductPage.new(
+        products: product_cards,
+        next_cursor: page_info["hasNextPage"] ? edges.last&.dig("cursor") : nil,
+        prev_cursor: page_info["hasPreviousPage"] ? edges.first&.dig("cursor") : nil
+      )
+    end
+
+    def fallback_page(first:, after:, before:)
+      rows = fallback_rows
+      return ProductPage.new(products: [], next_cursor: nil, prev_cursor: nil) if rows.blank?
+
+      per_page = [[first.to_i, 1].max, 24].min
+
+      if before.present?
+        end_index = decode_fallback_cursor(before) || rows.length
+        end_index = [[end_index, 0].max, rows.length].min
+        start_index = [end_index - per_page, 0].max
+      else
+        start_index = after.present? ? (decode_fallback_cursor(after).to_i + 1) : 0
+        start_index = [[start_index, 0].max, rows.length].min
+        end_index = [start_index + per_page, rows.length].min
+      end
+
+      window = rows[start_index...end_index] || []
+      cards = window.map do |row|
+        ProductCard.new(
+          id: row[:id],
+          handle: row[:handle],
+          title: row[:title],
+          description: truncate(row[:description]),
+          image_url: row[:image_url],
+          price: row[:price]
+        )
+      end
+
+      has_previous = start_index.positive?
+      has_next = end_index < rows.length
+
+      ProductPage.new(
+        products: cards,
+        next_cursor: has_next ? encode_fallback_cursor(end_index - 1) : nil,
+        prev_cursor: has_previous ? encode_fallback_cursor(start_index) : nil
+      )
+    end
 
     def live_product(identifier)
       decoded_identifier = CGI.unescape(identifier.to_s)
@@ -138,6 +264,19 @@ module Shopify
           price: row[:price]
         )
       end
+    end
+
+    def encode_fallback_cursor(index)
+      Base64.urlsafe_encode64("idx:#{index}")
+    end
+
+    def decode_fallback_cursor(cursor)
+      decoded = Base64.urlsafe_decode64(cursor.to_s)
+      return nil if !decoded.start_with?("idx:")
+
+      Integer(decoded.delete_prefix("idx:"), exception: false)
+    rescue ArgumentError
+      nil
     end
 
     def fallback_rows

--- a/app/views/storefront/index.html.erb
+++ b/app/views/storefront/index.html.erb
@@ -8,6 +8,9 @@
     <p class="sublead">
       <%= @shopify_connected ? "Live product data is loading from your Shopify storefront." : "Running in showcase mode. Set Shopify env vars to pull live products." %>
     </p>
+    <p class="hero-actions">
+      <%= link_to "Browse Full Collection", shop_path, class: "pagination-link" %>
+    </p>
   </section>
 
   <section class="collection-header">

--- a/app/views/storefront/shop.html.erb
+++ b/app/views/storefront/shop.html.erb
@@ -1,0 +1,47 @@
+<% content_for :title, "Shop | Indigo Abyss" %>
+
+<main class="site-shell">
+  <section class="hero">
+    <p class="eyebrow">Indigo Abyss Collection</p>
+    <h1>Shop Raw Denim</h1>
+    <p class="lead">Browse the full Indigo Abyss catalog with cursor-based pagination.</p>
+    <p class="sublead"><%= @shopify_connected ? "Live Shopify collection" : "Showcase mode collection" %></p>
+  </section>
+
+  <% if @catalog_page.empty? %>
+    <section class="empty-state" aria-live="polite">
+      <h2>No products available yet</h2>
+      <p>We do not have any products to display right now. Please check back soon.</p>
+      <%= link_to "Back to Home", root_path, class: "pagination-link" %>
+    </section>
+  <% else %>
+    <section class="product-grid" aria-label="Shop products">
+      <% @catalog_page.products.each do |product| %>
+        <%= link_to product_path(product.handle || product.id), class: "product-card-link", aria: { label: "View #{product.title}" } do %>
+          <article class="product-card">
+            <img src="<%= product.image_url %>" alt="<%= product.title %>" loading="lazy">
+            <div class="product-body">
+              <h3><%= product.title %></h3>
+              <p><%= product.description %></p>
+              <span class="price"><%= product.price %></span>
+            </div>
+          </article>
+        <% end %>
+      <% end %>
+    </section>
+
+    <nav class="pagination-nav" aria-label="Collection pagination">
+      <% if @catalog_page.prev_cursor.present? %>
+        <%= link_to "Previous", shop_path(before: @catalog_page.prev_cursor, per: params[:per]), class: "pagination-link" %>
+      <% else %>
+        <span class="pagination-link disabled" aria-disabled="true">Previous</span>
+      <% end %>
+
+      <% if @catalog_page.next_cursor.present? %>
+        <%= link_to "Next", shop_path(after: @catalog_page.next_cursor, per: params[:per]), class: "pagination-link" %>
+      <% else %>
+        <span class="pagination-link disabled" aria-disabled="true">Next</span>
+      <% end %>
+    </nav>
+  <% end %>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,6 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   root "storefront#index"
+  get "shop", to: "storefront#shop", as: :shop
   get "products/*id", to: "storefront#show", as: :product
 end

--- a/test/integration/storefront_shop_test.rb
+++ b/test/integration/storefront_shop_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+require "base64"
+require "nokogiri"
+
+class StorefrontShopTest < ActionDispatch::IntegrationTest
+  test "renders shop page with next link when more products exist" do
+    get "/shop", params: { per: 2 }
+
+    assert_response :success
+    assert_select "h1", "Shop Raw Denim"
+    assert_select "a", "Next"
+  end
+
+  test "renders previous link on later page" do
+    get "/shop", params: { per: 2 }
+
+    next_href = Nokogiri::HTML(response.body).at_css("a[href*='after=']")&.[]("href")
+    assert next_href.present?, "Expected a next link"
+
+    get next_href
+
+    assert_response :success
+    assert_select "a", "Previous"
+  end
+
+  test "renders empty state when pagination cursor is beyond available data" do
+    cursor = Base64.urlsafe_encode64("idx:999")
+
+    get "/shop", params: { after: cursor, per: 2 }
+
+    assert_response :success
+    assert_select "h2", "No products available yet"
+  end
+end


### PR DESCRIPTION
Implements Issue #2.\n\n## What changed\n- Added /shop route and storefront action\n- Added cursor-based pagination for Shopify and fallback modes\n- Added collection view with next/previous controls and empty state\n- Added integration tests for shop pagination\n\nCloses #2