### PR TITLE
chore: move fallback product data into config fixture

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ruby bin/prepush

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ Set these values in your environment (or `.env` via your preferred loader):
 - `SHOPIFY_STOREFRONT_ACCESS_TOKEN`
 
 If these are missing, the homepage runs in showcase mode with curated sample denim products.
+The fallback product source is maintained in `config/fallback_products.yml`.
+
+## Optional pre-push checks
+
+Install project git hooks once:
+
+```bash
+ruby bin/install-hooks
+```
+
+Then every `git push` runs:
+
+- `bin/rubocop`
+- `bin/rails test`
 
 ## Current app behavior
 

--- a/app/services/shopify/product_catalog.rb
+++ b/app/services/shopify/product_catalog.rb
@@ -1,8 +1,11 @@
 require "cgi"
 require "base64"
+require "yaml"
 
 module Shopify
   class ProductCatalog
+    FALLBACK_PRODUCTS_PATH = Rails.root.join("config/fallback_products.yml").freeze
+
     FEATURED_PRODUCTS_QUERY = <<~GRAPHQL
       query DenimShowcase($first: Int!) {
         products(first: $first, sortKey: BEST_SELLING) {
@@ -308,41 +311,18 @@ module Shopify
     end
 
     def fallback_rows
-      [
-        {
-          id: "sample-001",
-          handle: "abyss-selvedge-14oz",
-          title: "Abyss Selvedge 14oz",
-          description: "Straight fit, loom-state selvedge woven for high-contrast fades and long break-in life.",
-          image_url: "https://images.unsplash.com/photo-1582552938357-32b906df40cb?auto=format&fit=crop&w=1200&q=80",
-          price: "USD 168.00",
-          price_amount: 168.00,
-          currency_code: "USD",
-          variant_id: "gid://shopify/ProductVariant/401001"
-        },
-        {
-          id: "sample-002",
-          handle: "nocturne-taper-13oz",
-          title: "Nocturne Taper 13oz",
-          description: "Roomy top block with an aggressive taper and deep indigo cast for clean vertical fade lines.",
-          image_url: "https://images.unsplash.com/photo-1473966968600-fa801b869a1a?auto=format&fit=crop&w=1200&q=80",
-          price: "USD 154.00",
-          price_amount: 154.00,
-          currency_code: "USD",
-          variant_id: "gid://shopify/ProductVariant/401002"
-        },
-        {
-          id: "sample-003",
-          handle: "rinse-black-warp-12oz",
-          title: "Rinse Black Warp 12oz",
-          description: "Sulfur-black warp with indigo core yarn for tone-rich wear patterns and subtle electric highs.",
-          image_url: "https://images.unsplash.com/photo-1552902865-b72c031ac5ea?auto=format&fit=crop&w=1200&q=80",
-          price: "USD 182.00",
-          price_amount: 182.00,
-          currency_code: "USD",
-          variant_id: "gid://shopify/ProductVariant/401003"
-        }
-      ]
+      @fallback_rows ||= begin
+        rows = YAML.safe_load_file(FALLBACK_PRODUCTS_PATH, permitted_classes: [], aliases: false)
+        Array(rows).map { |row| normalize_fallback_row(row) }
+      rescue StandardError
+        []
+      end
+    end
+
+    def normalize_fallback_row(row)
+      normalized = row.to_h.transform_keys(&:to_sym)
+      normalized[:price_amount] = normalized[:price_amount].to_f if normalized[:price_amount].present?
+      normalized
     end
 
     def money_label(amount:, currency:)

--- a/bin/install-hooks
+++ b/bin/install-hooks
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+success = system("git", "config", "core.hooksPath", ".githooks")
+abort("Failed to set core.hooksPath") unless success
+
+puts "Git hooks installed: .githooks"

--- a/bin/prepush
+++ b/bin/prepush
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rbconfig"
+
+ENV["RUBOCOP_CACHE_ROOT"] ||= "tmp/rubocop_cache"
+
+checks = [
+  [RbConfig.ruby, "bin/rubocop"],
+  [RbConfig.ruby, "bin/rails", "test"]
+]
+
+checks.each do |cmd|
+  puts "==> #{cmd.join(' ')}"
+  next if system(*cmd)
+
+  warn "Check failed: #{cmd.join(' ')}"
+  exit 1
+end
+
+puts "All pre-push checks passed."

--- a/config/fallback_products.yml
+++ b/config/fallback_products.yml
@@ -1,0 +1,27 @@
+- id: sample-001
+  handle: abyss-selvedge-14oz
+  title: Abyss Selvedge 14oz
+  description: Straight fit, loom-state selvedge woven for high-contrast fades and long break-in life.
+  image_url: https://images.unsplash.com/photo-1582552938357-32b906df40cb?auto=format&fit=crop&w=1200&q=80
+  price: USD 168.00
+  price_amount: 168.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401001
+- id: sample-002
+  handle: nocturne-taper-13oz
+  title: Nocturne Taper 13oz
+  description: Roomy top block with an aggressive taper and deep indigo cast for clean vertical fade lines.
+  image_url: https://images.unsplash.com/photo-1473966968600-fa801b869a1a?auto=format&fit=crop&w=1200&q=80
+  price: USD 154.00
+  price_amount: 154.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401002
+- id: sample-003
+  handle: rinse-black-warp-12oz
+  title: Rinse Black Warp 12oz
+  description: Sulfur-black warp with indigo core yarn for tone-rich wear patterns and subtle electric highs.
+  image_url: https://images.unsplash.com/photo-1552902865-b72c031ac5ea?auto=format&fit=crop&w=1200&q=80
+  price: USD 182.00
+  price_amount: 182.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401003

--- a/test/services/shopify/product_catalog_test.rb
+++ b/test/services/shopify/product_catalog_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+module Shopify
+  class ProductCatalogTest < ActiveSupport::TestCase
+    class OfflineClient
+      def configured?
+        false
+      end
+    end
+
+    test "featured reads fallback products from config fixture" do
+      catalog = ProductCatalog.new(client: OfflineClient.new)
+
+      products = catalog.featured(limit: 2)
+
+      assert_equal 2, products.length
+      assert_equal "Abyss Selvedge 14oz", products.first.title
+      assert_equal "gid://shopify/ProductVariant/401001", products.first.variant_id
+      assert_equal "USD 168.00", products.first.price
+    end
+
+    test "find returns fallback product by handle" do
+      catalog = ProductCatalog.new(client: OfflineClient.new)
+
+      product = catalog.find("nocturne-taper-13oz")
+
+      assert_not_nil product
+      assert_equal "Nocturne Taper 13oz", product.title
+      assert_equal "gid://shopify/ProductVariant/401002", product.variant_id
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- move hardcoded fallback product rows into config/fallback_products.yml
- update Shopify::ProductCatalog to load and normalize fallback rows from that fixture file
- add service tests that cover fallback rendering path from the fixture source
- add optional local pre-push guardrails (in/prepush, .githooks/pre-push, in/install-hooks)
- document fallback data source and hook setup in README

## Testing
- ruby bin/prepush

Closes #5