### PR TITLE
feat: add product sub-categories (pants, shirts, jackets, accessories)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -439,3 +439,23 @@ body {
 }
 
 
+.category-filters {
+  margin: 1rem 0;
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.pagination-link.active {
+  border-color: rgba(165, 201, 255, 0.9);
+  background: rgba(49, 88, 164, 0.68);
+  color: #fff;
+}
+
+.product-category {
+  margin: 0.35rem 0 0.45rem;
+  color: #aecdff;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}

--- a/app/controllers/storefront_controller.rb
+++ b/app/controllers/storefront_controller.rb
@@ -13,10 +13,13 @@ class StorefrontController < ApplicationController
     catalog = Shopify::ProductCatalog.new(client: client)
 
     @shopify_connected = client.configured?
+    @categories = Shopify::ProductCatalog::SUPPORTED_CATEGORIES
+    @selected_category = params[:category].to_s.presence
     @catalog_page = catalog.page(
       first: per_page,
       after: params[:after],
-      before: params[:before]
+      before: params[:before],
+      category: @selected_category
     )
     set_storefront_notice(client)
   end

--- a/app/models/product_card.rb
+++ b/app/models/product_card.rb
@@ -1,7 +1,7 @@
 class ProductCard
-  attr_reader :id, :handle, :title, :description, :image_url, :price, :price_amount, :currency_code, :variant_id
+  attr_reader :id, :handle, :title, :description, :image_url, :price, :price_amount, :currency_code, :variant_id, :category
 
-  def initialize(id:, title:, description:, image_url:, price:, handle: nil, price_amount: nil, currency_code: nil, variant_id: nil)
+  def initialize(id:, title:, description:, image_url:, price:, handle: nil, price_amount: nil, currency_code: nil, variant_id: nil, category: nil)
     @id = id
     @handle = handle
     @title = title
@@ -11,5 +11,6 @@ class ProductCard
     @price_amount = price_amount
     @currency_code = currency_code
     @variant_id = variant_id
+    @category = category
   end
 end

--- a/app/services/shopify/product_catalog.rb
+++ b/app/services/shopify/product_catalog.rb
@@ -5,6 +5,7 @@ require "yaml"
 module Shopify
   class ProductCatalog
     FALLBACK_PRODUCTS_PATH = Rails.root.join("config/fallback_products.yml").freeze
+    SUPPORTED_CATEGORIES = %w[pants shirts jackets accessories].freeze
 
     FEATURED_PRODUCTS_QUERY = <<~GRAPHQL
       query DenimShowcase($first: Int!) {
@@ -14,6 +15,7 @@ module Shopify
             handle
             title
             description
+            productType
             featuredImage {
               url
               altText
@@ -44,6 +46,7 @@ module Shopify
               handle
               title
               description
+              productType
               featuredImage {
                 url
                 altText
@@ -79,6 +82,7 @@ module Shopify
               handle
               title
               description
+              productType
               featuredImage {
                 url
                 altText
@@ -111,6 +115,7 @@ module Shopify
           handle
           title
           description
+          productType
           featuredImage {
             url
             altText
@@ -138,6 +143,7 @@ module Shopify
             handle
             title
             description
+            productType
             featuredImage {
               url
               altText
@@ -172,10 +178,11 @@ module Shopify
       nodes.map { |node| to_product_card(node, truncate_description: true) }
     end
 
-    def page(first:, after: nil, before: nil)
-      return fallback_page(first: first, after: after, before: before) if !@client.configured?
+    def page(first:, after: nil, before: nil, category: nil)
+      return fallback_page(first: first, after: after, before: before, category: category) if !@client.configured?
 
-      live_page(first: first, after: after, before: before) || fallback_page(first: first, after: after, before: before)
+      live_page(first: first, after: after, before: before, category: category) ||
+        fallback_page(first: first, after: after, before: before, category: category)
     end
 
     def find(identifier)
@@ -191,7 +198,7 @@ module Shopify
 
     private
 
-    def live_page(first:, after:, before:)
+    def live_page(first:, after:, before:, category:)
       if before.present?
         data = @client.query(query: PRODUCTS_PAGE_BACKWARD_QUERY, variables: { last: first, before: before })
       else
@@ -203,6 +210,7 @@ module Shopify
 
       edges = products_data["edges"] || []
       product_cards = edges.map { |edge| to_product_card(edge["node"], truncate_description: true) }
+      product_cards = filter_products_by_category(product_cards, category)
       page_info = products_data["pageInfo"] || {}
 
       ProductPage.new(
@@ -212,8 +220,8 @@ module Shopify
       )
     end
 
-    def fallback_page(first:, after:, before:)
-      rows = fallback_rows
+    def fallback_page(first:, after:, before:, category:)
+      rows = filtered_rows(category)
       return ProductPage.new(products: [], next_cursor: nil, prev_cursor: nil) if rows.blank?
 
       per_page = [ [ first.to_i, 1 ].max, 24 ].min
@@ -267,7 +275,8 @@ module Shopify
         price: money_label(amount: amount, currency: currency),
         price_amount: amount,
         currency_code: currency,
-        variant_id: node.dig("variants", "nodes", 0, "id")
+        variant_id: node.dig("variants", "nodes", 0, "id"),
+        category: normalize_category(node["productType"])
       )
     end
 
@@ -293,8 +302,39 @@ module Shopify
         price: row[:price],
         price_amount: row[:price_amount],
         currency_code: row[:currency_code],
-        variant_id: row[:variant_id]
+        variant_id: row[:variant_id],
+        category: normalize_category(row[:category])
       )
+    end
+
+    def filtered_rows(category)
+      normalized = category_filter(category)
+      return fallback_rows if normalized.nil?
+      return [] if normalized == :invalid
+
+      fallback_rows.select { |row| normalize_category(row[:category]) == normalized }
+    end
+
+    def filter_products_by_category(products, category)
+      normalized = category_filter(category)
+      return products if normalized.nil?
+      return [] if normalized == :invalid
+
+      products.select { |product| product.category == normalized }
+    end
+
+    def category_filter(value)
+      raw = value.to_s.strip.downcase
+      return nil if raw.blank?
+
+      SUPPORTED_CATEGORIES.include?(raw) ? raw : :invalid
+    end
+
+    def normalize_category(value)
+      normalized = value.to_s.strip.downcase
+      return nil if normalized.blank?
+
+      SUPPORTED_CATEGORIES.include?(normalized) ? normalized : nil
     end
 
     def encode_fallback_cursor(index)

--- a/app/views/storefront/shop.html.erb
+++ b/app/views/storefront/shop.html.erb
@@ -8,10 +8,20 @@
     <p class="sublead"><%= @shopify_connected ? "Live Shopify collection" : "Showcase mode collection" %></p>
   </section>
 
+  <nav class="category-filters" aria-label="Category filters">
+    <%= link_to "All", shop_path(per: params[:per]), class: "pagination-link #{'active' if @selected_category.blank?}" %>
+    <% @categories.each do |category| %>
+      <% label = category.capitalize %>
+      <%= link_to label, shop_path(category: category, per: params[:per]), class: "pagination-link #{'active' if @selected_category == category}" %>
+    <% end %>
+  </nav>
+
   <% if @catalog_page.empty? %>
     <section class="empty-state" aria-live="polite">
       <h2>No products available yet</h2>
-      <p>We do not have any products to display right now. Please check back soon.</p>
+      <p>
+        <%= @selected_category.present? ? "No products found in #{@selected_category.capitalize}. Try another category." : "We do not have any products to display right now. Please check back soon." %>
+      </p>
       <%= link_to "Back to Home", root_path, class: "pagination-link" %>
     </section>
   <% else %>
@@ -22,6 +32,9 @@
             <img src="<%= product.image_url %>" alt="<%= product.title %>" loading="lazy">
             <div class="product-body">
               <h3><%= product.title %></h3>
+              <% if product.category.present? %>
+                <p class="product-category"><%= product.category.capitalize %></p>
+              <% end %>
               <p><%= product.description %></p>
               <span class="price"><%= product.price %></span>
             </div>
@@ -32,13 +45,13 @@
 
     <nav class="pagination-nav" aria-label="Collection pagination">
       <% if @catalog_page.prev_cursor.present? %>
-        <%= link_to "Previous", shop_path(before: @catalog_page.prev_cursor, per: params[:per]), class: "pagination-link" %>
+        <%= link_to "Previous", shop_path(before: @catalog_page.prev_cursor, per: params[:per], category: @selected_category), class: "pagination-link" %>
       <% else %>
         <span class="pagination-link disabled" aria-disabled="true">Previous</span>
       <% end %>
 
       <% if @catalog_page.next_cursor.present? %>
-        <%= link_to "Next", shop_path(after: @catalog_page.next_cursor, per: params[:per]), class: "pagination-link" %>
+        <%= link_to "Next", shop_path(after: @catalog_page.next_cursor, per: params[:per], category: @selected_category), class: "pagination-link" %>
       <% else %>
         <span class="pagination-link disabled" aria-disabled="true">Next</span>
       <% end %>

--- a/config/fallback_products.yml
+++ b/config/fallback_products.yml
@@ -7,6 +7,7 @@
   price_amount: 168.00
   currency_code: USD
   variant_id: gid://shopify/ProductVariant/401001
+  category: pants
 - id: sample-002
   handle: nocturne-taper-13oz
   title: Nocturne Taper 13oz
@@ -16,6 +17,7 @@
   price_amount: 154.00
   currency_code: USD
   variant_id: gid://shopify/ProductVariant/401002
+  category: pants
 - id: sample-003
   handle: rinse-black-warp-12oz
   title: Rinse Black Warp 12oz
@@ -25,3 +27,174 @@
   price_amount: 182.00
   currency_code: USD
   variant_id: gid://shopify/ProductVariant/401003
+  category: jackets
+- id: sample-004
+  handle: railcar-straight-15oz
+  title: Railcar Straight 15oz
+  description: Classic straight silhouette with dense yarn tension for bold whiskers and durable structure.
+  image_url: https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=1200&q=80
+  price: USD 176.00
+  price_amount: 176.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401004
+  category: pants
+- id: sample-005
+  handle: harbor-relaxed-13oz
+  title: Harbor Relaxed 13oz
+  description: Relaxed top block and easy leg shape built for everyday wear without losing clean stacks.
+  image_url: https://images.unsplash.com/photo-1582552938357-32b906df40cb?auto=format&fit=crop&w=1200&q=80
+  price: USD 149.00
+  price_amount: 149.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401005
+  category: pants
+- id: sample-006
+  handle: arc-taper-14oz
+  title: Arc Taper 14oz
+  description: Athletic seat with controlled taper engineered for sharp lines and easy movement.
+  image_url: https://images.unsplash.com/photo-1473966968600-fa801b869a1a?auto=format&fit=crop&w=1200&q=80
+  price: USD 171.00
+  price_amount: 171.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401006
+  category: pants
+- id: sample-007
+  handle: midnight-slim-12oz
+  title: Midnight Slim 12oz
+  description: Lightweight slim denim with deep blue-black cast for fast break-in and refined fades.
+  image_url: https://images.unsplash.com/photo-1552902865-b72c031ac5ea?auto=format&fit=crop&w=1200&q=80
+  price: USD 142.00
+  price_amount: 142.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401007
+  category: shirts
+- id: sample-008
+  handle: foundry-wide-16oz
+  title: Foundry Wide 16oz
+  description: Wider leg cut in heavyweight denim for dramatic drape and high-contrast wear patterns.
+  image_url: https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=1200&q=80
+  price: USD 194.00
+  price_amount: 194.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401008
+  category: pants
+- id: sample-009
+  handle: low-tide-crop-11oz
+  title: Low Tide Crop 11oz
+  description: Cropped inseam with clean hem and airy weight tuned for warm weather rotations.
+  image_url: https://images.unsplash.com/photo-1582552938357-32b906df40cb?auto=format&fit=crop&w=1200&q=80
+  price: USD 133.00
+  price_amount: 133.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401009
+  category: accessories
+- id: sample-010
+  handle: ridge-regular-13oz
+  title: Ridge Regular 13oz
+  description: Balanced regular fit with subtle taper and versatile fabric for year-round use.
+  image_url: https://images.unsplash.com/photo-1473966968600-fa801b869a1a?auto=format&fit=crop&w=1200&q=80
+  price: USD 158.00
+  price_amount: 158.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401010
+  category: shirts
+- id: sample-011
+  handle: polar-selvedge-15oz
+  title: Polar Selvedge 15oz
+  description: High-density selvedge weave made for crisp combs and long-term fade depth.
+  image_url: https://images.unsplash.com/photo-1552902865-b72c031ac5ea?auto=format&fit=crop&w=1200&q=80
+  price: USD 186.00
+  price_amount: 186.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401011
+  category: jackets
+- id: sample-012
+  handle: furnace-taper-14oz
+  title: Furnace Taper 14oz
+  description: Structured taper with reinforced pockets and stitch density for hard daily wear.
+  image_url: https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=1200&q=80
+  price: USD 173.00
+  price_amount: 173.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401012
+  category: jackets
+- id: sample-013
+  handle: harbor-slim-straight-12oz
+  title: Harbor Slim Straight 12oz
+  description: Slim-straight profile with soft hand-feel that still yields authentic fade texture.
+  image_url: https://images.unsplash.com/photo-1582552938357-32b906df40cb?auto=format&fit=crop&w=1200&q=80
+  price: USD 147.00
+  price_amount: 147.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401013
+  category: pants
+- id: sample-014
+  handle: forge-relaxed-taper-15oz
+  title: Forge Relaxed Taper 15oz
+  description: Relaxed rise with defined taper for mobility up top and cleaner ankle break.
+  image_url: https://images.unsplash.com/photo-1473966968600-fa801b869a1a?auto=format&fit=crop&w=1200&q=80
+  price: USD 188.00
+  price_amount: 188.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401014
+  category: jackets
+- id: sample-015
+  handle: shadow-crop-taper-11oz
+  title: Shadow Crop Taper 11oz
+  description: Trim crop taper in lighter denim designed for summer stacks and sneaker pairings.
+  image_url: https://images.unsplash.com/photo-1552902865-b72c031ac5ea?auto=format&fit=crop&w=1200&q=80
+  price: USD 136.00
+  price_amount: 136.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401015
+  category: accessories
+- id: sample-016
+  handle: kiln-regular-14oz
+  title: Kiln Regular 14oz
+  description: Regular fit with medium rise and robust twill for steady break-in progression.
+  image_url: https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=1200&q=80
+  price: USD 169.00
+  price_amount: 169.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401016
+  category: shirts
+- id: sample-017
+  handle: cobalt-wide-leg-13oz
+  title: Cobalt Wide Leg 13oz
+  description: Wide-leg silhouette with fluid drape and deep cobalt cast for vintage-inspired fits.
+  image_url: https://images.unsplash.com/photo-1582552938357-32b906df40cb?auto=format&fit=crop&w=1200&q=80
+  price: USD 161.00
+  price_amount: 161.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401017
+  category: pants
+- id: sample-018
+  handle: vapor-skinny-10oz
+  title: Vapor Skinny 10oz
+  description: Stretch-inflected skinny profile for close fit comfort with lightweight indigo tone.
+  image_url: https://images.unsplash.com/photo-1473966968600-fa801b869a1a?auto=format&fit=crop&w=1200&q=80
+  price: USD 128.00
+  price_amount: 128.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401018
+  category: shirts
+- id: sample-019
+  handle: anvil-straight-15oz
+  title: Anvil Straight 15oz
+  description: Firm straight fit with chain-stitched hems and copper hardware for heritage detail.
+  image_url: https://images.unsplash.com/photo-1552902865-b72c031ac5ea?auto=format&fit=crop&w=1200&q=80
+  price: USD 184.00
+  price_amount: 184.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401019
+  category: jackets
+- id: sample-020
+  handle: atlas-relaxed-straight-14oz
+  title: Atlas Relaxed Straight 14oz
+  description: Relaxed straight profile balancing room and structure for all-day comfort.
+  image_url: https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=1200&q=80
+  price: USD 172.00
+  price_amount: 172.00
+  currency_code: USD
+  variant_id: gid://shopify/ProductVariant/401020
+  category: accessories

--- a/test/integration/storefront_shop_test.rb
+++ b/test/integration/storefront_shop_test.rb
@@ -45,6 +45,23 @@ class StorefrontShopTest < ActionDispatch::IntegrationTest
     assert_select "h2", "No products available yet"
   end
 
+  test "renders category filters and supports category query" do
+    get "/shop", params: { category: "jackets", per: 24 }
+
+    assert_response :success
+    assert_select "nav.category-filters"
+    assert_select "a.pagination-link.active", "Jackets"
+    assert_select ".product-category", minimum: 1
+    assert_select ".product-category", /Jackets/
+  end
+
+  test "renders category-specific empty message when category has no products" do
+    get "/shop", params: { category: "nonexistent", per: 24 }
+
+    assert_response :success
+    assert_select "p", /No products found in/
+  end
+
   test "shows fallback alert when live storefront query fails" do
     with_storefront_client(FakeClient.new) do
       get "/shop"

--- a/test/services/shopify/product_catalog_test.rb
+++ b/test/services/shopify/product_catalog_test.rb
@@ -83,5 +83,24 @@ module Shopify
       assert_equal 1, products.length
       assert_equal "Abyss Selvedge 14oz", products.first.title
     end
+
+    test "fallback fixture now includes 20 categorized products" do
+      catalog = ProductCatalog.new(client: OfflineClient.new)
+
+      products = catalog.featured(limit: 24)
+
+      assert_equal 20, products.length
+      assert_equal "pants", products.first.category
+      assert_equal "accessories", products.last.category
+    end
+
+    test "fallback page filters by supported category" do
+      catalog = ProductCatalog.new(client: OfflineClient.new)
+
+      page = catalog.page(first: 24, category: "jackets")
+
+      assert page.products.any?
+      assert page.products.all? { |product| product.category == "jackets" }
+    end
   end
 end


### PR DESCRIPTION
## Summary
- extend ProductCard and ProductCatalog to support normalized product categories
- add category filtering support to ProductCatalog#page for both live and fallback paths
- update shop controller/view to expose category filter controls and category-aware empty states
- add category labels in product cards on /shop
- expand fallback fixture with categorized products across pants, shirts, jackets, and accessories
- add service and integration tests for category filtering behavior

## Testing
- ruby bin/prepush

Closes #19